### PR TITLE
Make Request Context Accessible To Logger

### DIFF
--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -41,19 +41,12 @@ function abortStreamingResponse(res) {
 
 module.exports = function (config) {
     config = config || {};
-    var logger = config.logger;
-    var customReporter;
 
-    if (!logger) {
-        // default logger to stderr.
-        logger = function () {
-            return { error: console.log.bind(console) };
-        };
-    } else if (typeof logger !== 'function') {
-        logger = function () {
-            return config.logger;
-        };
-    }
+    var logger = config.logger || {
+        error: console.log.bind(console)
+    };
+
+    var reporter = config.reporter;
 
     return function errorHandler(err, req, res, next) {
         if (typeof err !== 'object') {
@@ -85,7 +78,16 @@ module.exports = function (config) {
                     body.password = '<omitted>';
                 }
             }
-            logger(err, req, res).error(req.connection.remoteAddress, req.method, req.originalUrl, statusCode, err.stack, err.data, util.inspect(body), util.inspect(req.headers));
+
+            var _logger;
+
+            if (reporter) {
+                _logger = reporter(err, req, res);
+            } else {
+                _logger = logger;
+            }
+
+            _logger.error(req.connection.remoteAddress, req.method, req.originalUrl, statusCode, err.stack, err.data, util.inspect(body), util.inspect(req.headers));
         }
         responseObj.stack = err.stack.split(/\n\s*/);
 
@@ -97,10 +99,6 @@ module.exports = function (config) {
 
         if (responseObj.headersAlreadySent) {
             responseObj.headersAlreadySent = undefined;
-        }
-
-        if (customReporter) {
-            customReporter(err, req, res);
         }
 
         if (!config.includeStackTrace) {

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -44,9 +44,15 @@ module.exports = function (config) {
     var logger = config.logger;
     var customReporter;
 
-    // default logger to stderr.
     if (!logger) {
-        logger = { error: console.log.bind(console) };
+        // default logger to stderr.
+        logger = function () {
+            return { error: console.log.bind(console) };
+        };
+    } else if (typeof logger !== 'function') {
+        logger = function () {
+            return config.logger;
+        };
     }
 
     return function errorHandler(err, req, res, next) {
@@ -79,7 +85,7 @@ module.exports = function (config) {
                     body.password = '<omitted>';
                 }
             }
-            logger.error(req.connection.remoteAddress, req.method, req.originalUrl, statusCode, err.stack, err.data, util.inspect(body), util.inspect(req.headers));
+            logger(err, req, res).error(req.connection.remoteAddress, req.method, req.originalUrl, statusCode, err.stack, err.data, util.inspect(body), util.inspect(req.headers));
         }
         responseObj.stack = err.stack.split(/\n\s*/);
 

--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
     "travis": "istanbul --include-all-sources cover _mocha -- --reporter spec"
   },
   "dependencies": {
-    "httperrors": "1.1.0"
+    "httperrors": "2.1.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.6",
-    "express": "4.13.3",
-    "istanbul": "0.4.1",
+    "coveralls": "2.11.15",
+    "express": "4.14.0",
+    "istanbul": "0.4.5",
     "magicpen-media": "1.5.1",
-    "messy": "6.6.2",
-    "mocha": "2.3.4",
-    "unexpected": "10.3.1",
-    "unexpected-express": "8.0.0",
-    "unexpected-messy": "5.0.0"
+    "messy": "6.12.2",
+    "mocha": "3.2.0",
+    "unexpected": "10.21.1",
+    "unexpected-express": "8.3.3",
+    "unexpected-messy": "6.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "magicpen-media": "1.5.1",
     "messy": "6.12.2",
     "mocha": "3.2.0",
+    "sinon": "1.17.7",
     "unexpected": "10.21.1",
     "unexpected-express": "8.3.3",
-    "unexpected-messy": "6.2.0"
+    "unexpected-messy": "6.2.0",
+    "unexpected-sinon": "10.5.1"
   }
 }

--- a/test/errorHandler.spec.js
+++ b/test/errorHandler.spec.js
@@ -6,6 +6,7 @@ var silentLogger = {
 var expect = require('unexpected')
     .clone()
     .installPlugin(require('unexpected-express'))
+    .installPlugin(require('unexpected-sinon'))
     .addAssertion('to yield response', function (expect, subject, value) {
         var handler = subject.handler || function (req, res, next) {
             next(subject.error || new Error('DefaultMockError'));
@@ -22,7 +23,7 @@ var expect = require('unexpected')
             response: value
         });
     });
-
+var sinon = require('sinon');
 
 describe('errorHandler', function () {
     it('should not handle non errors', function () {
@@ -245,6 +246,28 @@ describe('errorHandler', function () {
                     }
                 }
             });
+        });
+    });
+
+    describe('logger', function () {
+        it('should have access to request context', function () {
+            var logger = sinon.spy(function () {
+                return {
+                    error: function () {}
+                };
+            });
+
+            var middleware = errorHandler({
+                logger: logger
+            });
+
+            var error = new Error;
+            var request = { connection: {}, query: {}, is: function () {} };
+            var response = { locals: {}, status: function () { return { send: function() {} } } };
+
+            middleware(error, request, response);
+
+            expect(logger, 'was called with', error, request, response);
         });
     });
 });

--- a/test/errorHandler.spec.js
+++ b/test/errorHandler.spec.js
@@ -249,16 +249,16 @@ describe('errorHandler', function () {
         });
     });
 
-    describe('logger', function () {
+    describe('reporter', function () {
         it('should have access to request context', function () {
-            var logger = sinon.spy(function () {
+            var reporter = sinon.spy(function () {
                 return {
                     error: function () {}
                 };
             });
 
             var middleware = errorHandler({
-                logger: logger
+                reporter: reporter
             });
 
             var error = new Error;
@@ -267,7 +267,7 @@ describe('errorHandler', function () {
 
             middleware(error, request, response);
 
-            expect(logger, 'was called with', error, request, response);
+            expect(reporter, 'was called with', error, request, response);
         });
     });
 });


### PR DESCRIPTION
**What am I trying to do?**

Using `express-errorhandler` with [`concurrency-logger`](https://www.npmjs.com/package/concurrency-logger), which needs access to the request context.

`log`/`log.error` is exposed in `res.locals`.

```js
app.use(errorHandler({
  logger: (err, req, res) => res.locals.log
});
```

![image](https://cloud.githubusercontent.com/assets/4450694/21610737/0bc01d10-d1ca-11e6-9d95-e9aa1f888c96.png)

What do you think, is this use case too specific? Then I'd just go ahead and write a separate error handler.

The changes are backwards compatible.

@gustavnikolaj  @joelmukuthu